### PR TITLE
Feature/#51 config pg id and notice url

### DIFF
--- a/public/assets/coffee/order-id-payment.coffee
+++ b/public/assets/coffee/order-id-payment.coffee
@@ -1,6 +1,6 @@
 $ ->
   IMP = window.IMP
-  IMP.init('imp77873889')
+  IMP.init(CONFIG.iamport.id)
 
   STATUS =
     choose_address: 49  # 주소선택
@@ -43,7 +43,7 @@ $ ->
       dataType: 'json'
       success: (data, textStatus, jqXHR) ->
 
-        IMP.request_pay
+        imp_params =
           pg:           'html5_inicis'
           pay_method:   pay_method
           merchant_uid: data.cid
@@ -53,8 +53,9 @@ $ ->
           buyer_name:   name
           buyer_tel:    $info.data('phone')
           buyer_addr:   $info.data('address1')
-          notice_url:   'https://test-share.theopencloset.net/webhooks/iamport'
-        , (res) ->
+        imp_params.notice_url = CONFIG.iamport.notice_url if CONFIG.iamport.notice_url?
+
+        IMP.request_pay imp_params, (res) ->
           payment_status = res.status
           unless res.success
             payment_status = "cancelled"

--- a/share.conf.sample
+++ b/share.conf.sample
@@ -44,8 +44,10 @@
         blouse    => 'https://avatar.theopencloset.net/avatar/2bbbc09c29efa9bebd8718aa6f9d7bae',
     },
     iamport => {
-        key    => $ENV{OPENCLOSET_IAMPORT_API_KEY},
-        secret => $ENV{OPENCLOSET_IAMPORT_API_SECRET},
+        id         => "imp12345678",
+        key        => $ENV{OPENCLOSET_IAMPORT_API_KEY},
+        secret     => $ENV{OPENCLOSET_IAMPORT_API_SECRET},
+        notice_url => q{}, # Override if you want to iamport server configuration
     },
     postcodify_url => "https://postcodify.theopencloset.net/api/postcode/search.json",
 };

--- a/templates/partials/config.html.ep
+++ b/templates/partials/config.html.ep
@@ -1,6 +1,10 @@
 %= javascript begin
   var CONFIG = {
-    postcodify_url: "<%= $self->config->{postcodify_url} %>"
+    postcodify_url: "<%= $self->config->{postcodify_url} %>",
+    iamport: {
+      id: "<%= $self->config->{iamport}{id} %>",
+      notice_url: "<%= $self->config->{iamport}{notice_url} %>"
+    }
   };
 % end
 


### PR DESCRIPTION
#51 

pg사의 가맹점 식별 번호는 고유하지만 설정 가능해야 하므로 `iamport.id` 설정으로 뺐습니다. 더불어 훅 주소의 경우 기본으로는 pg사의 관리자 화면에서 지정한 값을 사용하게 되어있지만, 개발 장비나 기타 등등의 이슈로 변경할 수 있도록 `iamport.notice_url` 설정으로 뺐습니다. 지정하지 않을 경우 pg사 관리자 화면의 값을 사용하며, 개발 장비에서는 자신이 원하는 주소로 지정하면 됩니다.